### PR TITLE
Fix displaying of dialog disk selection in arch-installer post

### DIFF
--- a/site/blog/archlinux-installer/index.md
+++ b/site/blog/archlinux-installer/index.md
@@ -125,7 +125,7 @@ devicelist=$(lsblk -dplnx size -o name,size | grep -Ev "boot|rpmb|loop" | tac)
 device=$(dialog --stdout --menu "Select installation disk" 0 0 0 ${devicelist}) || exit 1
 ```
 
-![dialog disk selection](/blog/archlinux-installer/01-dialog-disk.png)
+![dialog disk selection](./01-dialog-disk.png)
 
 In addition to looking fancy, this also reducing the amount of typing and
 therefore typos.


### PR DESCRIPTION
The "dialog disk selection" image in the custom arch linux installer wasn't displayed due to improper path.